### PR TITLE
fix: add backticks for DOCTYPE html tag

### DIFF
--- a/active-tasks/clean-code-s1e1.json
+++ b/active-tasks/clean-code-s1e1.json
@@ -30,7 +30,7 @@
     },
     {
       "type": "subtask",
-      "text": "Basic rule 1.2. Use lowercase: implemented in the whole project. All HTML-tags, attributes and their values, CSS selectors, CSS properties and their values must be in lowercase. <!DOCTYPE html> is an exception to this rule.",
+      "text": "Basic rule 1.2. Use lowercase: implemented in the whole project. All HTML-tags, attributes and their values, CSS selectors, CSS properties and their values must be in lowercase. `<!DOCTYPE html>` is an exception to this rule.",
       "max": 2
     },
     {
@@ -45,7 +45,7 @@
     },
     {
       "type": "subtask",
-      "text": "Basic rule 2.2. Document Type. <!DOCTYPE html> is the first tag in the HTML file which corresponds to a basic HTML5 document.",
+      "text": "Basic rule 2.2. Document Type. `<!DOCTYPE html>` is the first tag in the HTML file which corresponds to a basic HTML5 document.",
       "max": 2
     },
     {


### PR DESCRIPTION
Trying to fix DOCTYPE html tag in Clean-code form for it to display correctly