### PR TITLE
fix: fix react-class-components checklist penalties

### DIFF
--- a/active-tasks/react-class-components.json
+++ b/active-tasks/react-class-components.json
@@ -49,11 +49,6 @@
     },
     {
       "type": "penalty",
-      "text": "eslint-plugin-react-compiler isn't used or isn't configured to throw errors",
-      "max": -50
-    },
-    {
-      "type": "penalty",
       "text": "Usage of any",
       "max": -20
     },


### PR DESCRIPTION
Removed the penalty item from the checklist to align it with the current task requirements